### PR TITLE
Enable file-based logging

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -2,6 +2,7 @@ const db = require("../models");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 const generateToken = require("../utils/generateToken");
+const logger = require("../utils/logger");
 
 const User = db.User;
 
@@ -25,7 +26,7 @@ exports.register = async (req, res) => {
       token: generateToken(user.id),
     });
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return res.status(500).json({ message: "Kayıt sırasında bir hata oluştu." });
   }
 };
@@ -54,7 +55,7 @@ exports.login = async (req, res) => {
       token: generateToken(user.id),
     });
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return res.status(500).json({ message: "Giriş sırasında bir hata oluştu." });
   }
 };
@@ -78,7 +79,7 @@ exports.updateSubscriptionPlan = async (req, res) => {
       plan: req.user.subscriptionPlan,
     });
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(500).json({ message: "Abonelik planı güncellenemedi." });
   }
 };

--- a/controllers/publicController.js
+++ b/controllers/publicController.js
@@ -25,7 +25,7 @@ exports.getPublicMenu = async (req, res) => {
       categories,
     });
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(500).json({ message: "Menü alınamadı." });
   }
 };

--- a/controllers/restaurantController.js
+++ b/controllers/restaurantController.js
@@ -1,5 +1,6 @@
 const db = require("../models");
 const Restaurant = db.Restaurant;
+const logger = require("../utils/logger");
 
 exports.createRestaurant = async (req, res) => {
   try {
@@ -15,7 +16,7 @@ exports.createRestaurant = async (req, res) => {
 
     return res.status(201).json(restaurant);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(500).json({ message: "Restoran oluşturulamadı." });
   }
 };
@@ -28,7 +29,7 @@ exports.getMyRestaurants = async (req, res) => {
 
     return res.json(restaurants);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(500).json({ message: "Restoranlar alınamadı." });
   }
 };
@@ -46,7 +47,7 @@ exports.updateRestaurant = async (req, res) => {
     await restaurant.update(req.body);
     return res.json(restaurant);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(500).json({ message: "Restoran güncellenemedi." });
   }
 };
@@ -64,7 +65,7 @@ exports.deleteRestaurant = async (req, res) => {
     await restaurant.destroy();
     return res.json({ message: "Restoran silindi." });
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(500).json({ message: "Silme işlemi başarısız." });
   }
 };

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -1,5 +1,6 @@
 const jwt = require("jsonwebtoken");
 const db = require("../models");
+const logger = require("../utils/logger");
 
 const User = db.User;
 
@@ -23,7 +24,7 @@ const authMiddleware = async (req, res, next) => {
     req.user = user; // diğer endpointlerde kullanılabilir
     next();
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return res.status(401).json({ message: "Geçersiz token." });
   }
 };

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const cors = require("cors");
 const morgan = require("morgan");
 const db = require("./models");
 const errorHandler = require("./middlewares/errorHandler");
+const logger = require("./utils/logger");
 
 dotenv.config();
 
@@ -12,7 +13,7 @@ const app = express();
 // Middleware
 app.use(cors());
 app.use(express.json());
-app.use(morgan("dev"));
+app.use(morgan("combined", { stream: logger.stream }));
 
 // Routes
 app.use("/api/auth", require("./routes/authRoutes"));
@@ -27,6 +28,6 @@ app.use(errorHandler); // tüm rotalardan sonra tanımlanmalı
 
 db.sequelize.sync({ alter: true }).then(() => {
   app.listen(PORT, () => {
-    console.log(`Sunucu ${PORT} portunda çalışıyor`);
+    logger.info(`Sunucu ${PORT} portunda çalışıyor`);
   });
 });

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,4 +1,13 @@
 const { createLogger, format, transports } = require("winston");
+const fs = require("fs");
+const path = require("path");
+
+const logDir = path.join(__dirname, "..", "logs");
+
+// create logs directory if it doesn't exist
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir);
+}
 
 const logger = createLogger({
   level: "info",
@@ -10,11 +19,17 @@ const logger = createLogger({
   ),
   defaultMeta: { service: "qrmenu-backend" },
   transports: [
+    new transports.File({ filename: path.join(logDir, "error.log"), level: "error" }),
+    new transports.File({ filename: path.join(logDir, "combined.log") }),
     new transports.Console(),
-    // gelecekte şunlar da eklenebilir:
-    // new transports.File({ filename: 'logs/error.log', level: 'error' }),
-    // new transports.File({ filename: 'logs/combined.log' })
   ],
 });
+
+// stream interface for morgan
+logger.stream = {
+  write: (message) => {
+    logger.info(message.trim());
+  },
+};
 
 module.exports = logger;

--- a/utils/qrGenerator.js
+++ b/utils/qrGenerator.js
@@ -1,10 +1,11 @@
 const QRCode = require("qrcode");
+const logger = require("./logger");
 
 const generateQRCode = async (text) => {
   try {
     return await QRCode.toDataURL(text);
   } catch (err) {
-    console.error("QR oluşturulamadı:", err);
+    logger.error("QR oluşturulamadı: %O", err);
     return null;
   }
 };


### PR DESCRIPTION
## Summary
- add filesystem based winston logger
- forward morgan logs to the logger
- replace console.error calls with logger
- use logger for server startup message
- keep an empty `logs` directory for runtime log files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686297d7ef00832dae2ffa5cc0479d23